### PR TITLE
fix: 更准确的获取PTP mediainfo

### DIFF
--- a/src/source/ptp.js
+++ b/src/source/ptp.js
@@ -40,19 +40,19 @@ export default async () => {
     const { knownTags, otherTags } = getTags(otherInfo);
     TORRENT_INFO.videoType = source === 'WEB' ? 'web' : getVideoType(container, isRemux, codes, source);
     const isBluray = TORRENT_INFO.videoType.match(/bluray/i);
-    const { bdinfo, mediaInfo } = getBDInfoOrMediaInfo(descriptionData);
-    const mediaInfoOrBDInfo = isBluray ? bdinfo : mediaInfo;
     TORRENT_INFO.tags = { ...knownTags };
     TORRENT_INFO.otherTags = otherTags;
     TORRENT_INFO.resolution = resolution;
-    if (mediaInfoOrBDInfo) {
-      const getInfoFunc = isBluray ? getInfoFromBDInfo : getInfoFromMediaInfo;
-      TORRENT_INFO.mediaInfo = mediaInfoOrBDInfo;
-      const { videoCodec, audioCodec, mediaTags } = getInfoFunc(mediaInfoOrBDInfo);
-      TORRENT_INFO.videoCodec = videoCodec;
-      TORRENT_INFO.audioCodec = audioCodec;
-      TORRENT_INFO.tags = { ...TORRENT_INFO.tags, ...mediaTags };
-    }
+
+    // mediainfo
+    const mediaInfoOrBDInfo = getMediainfo();
+    const getInfoFunc = isBluray ? getInfoFromBDInfo : getInfoFromMediaInfo;
+    TORRENT_INFO.mediaInfo = mediaInfoOrBDInfo;
+    const { videoCodec, audioCodec, mediaTags } = getInfoFunc(mediaInfoOrBDInfo);
+    TORRENT_INFO.videoCodec = videoCodec;
+    TORRENT_INFO.audioCodec = audioCodec;
+    TORRENT_INFO.tags = { ...TORRENT_INFO.tags, ...mediaTags };
+
     let torrentName = torrentHeaderDom.data('releasename');
     torrentName = formatTorrentTitle(torrentName);
     TORRENT_INFO.title = torrentName;
@@ -211,3 +211,7 @@ function getTags (rawTags) {
     otherTags,
   };
 };
+
+function getMediainfo () {
+  return $('.mediainfo--in-release-description + blockquote.spoiler').text();
+}

--- a/src/source/ptp.js
+++ b/src/source/ptp.js
@@ -45,7 +45,7 @@ export default async () => {
     TORRENT_INFO.resolution = resolution;
 
     // mediainfo
-    const mediaInfoOrBDInfo = getMediainfo();
+    const mediaInfoOrBDInfo = mediaInfoArray.join('\n\n');
     const getInfoFunc = isBluray ? getInfoFromBDInfo : getInfoFromMediaInfo;
     TORRENT_INFO.mediaInfo = mediaInfoOrBDInfo;
     const { videoCodec, audioCodec, mediaTags } = getInfoFunc(mediaInfoOrBDInfo);
@@ -211,7 +211,3 @@ function getTags (rawTags) {
     otherTags,
   };
 };
-
-function getMediainfo () {
-  return $('.mediainfo--in-release-description + blockquote.spoiler').text();
-}


### PR DESCRIPTION
好多种子都不带`[mediainfo]..[/mediainfo]`的，而直接用`General..`，可以直接从HTML获取