### PR TITLE
Fix code scanning alert no. 37: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "jquery": "^3.7.1",
     "path-browserify": "^1.0.1",
     "preact": "^10.24.1",
-    "rc-notification": "4.4.0"
+    "rc-notification": "4.4.0",
+    "dompurify": "^3.1.7"
   },
   "packageManager": "yarn@4.5.0"
 }

--- a/src/source/gazelle-music.ts
+++ b/src/source/gazelle-music.ts
@@ -1,5 +1,6 @@
 import { getUrlParam, fetch, htmlToBBCode } from '../common';
 import { CURRENT_SITE_INFO, TORRENT_INFO, CURRENT_SITE_NAME } from '../const';
+import DOMPurify from 'dompurify';
 
 export default async () => {
   const torrentId = getUrlParam('torrentid');
@@ -44,6 +45,7 @@ async function getTorrentInfo (torrentId:string) {
   div.innerHTML = wikiBody;
   let description = bbBody || htmlToBBCode(div);
   description = `[img]${wikiImage}[/img]\n${description}`;
+  description = DOMPurify.sanitize(description);
   const descSource = new DOMParser().parseFromString(description, 'text/html');
   if (descSource.documentElement.textContent) {
     description = descSource.documentElement.textContent.replace(/\[\/?artist\]/g, '').replace(/\[url=https:\/\/redacted\.ch\/torrents\.php\?(taglist|recordlabel)=[a-zA-Z%0-9]*\]/g, '').replace(/(?<=(\[\/b\]|,)[\s\\.a-zA-Z]*)\[\/url\]/g, '');


### PR DESCRIPTION
Fixes [https://github.com/techmovie/easy-upload/security/code-scanning/37](https://github.com/techmovie/easy-upload/security/code-scanning/37)

To fix the problem, we need to ensure that any untrusted data is properly sanitized before being used in a context where it can be interpreted as HTML. Specifically, we should escape any HTML meta-characters in the `description` variable before parsing it with `DOMParser`.

The best way to fix this issue is to use a library like `DOMPurify` to sanitize the `description` variable. `DOMPurify` is a well-known library for sanitizing HTML and preventing XSS attacks.

1. Install `DOMPurify` as a dependency.
2. Import `DOMPurify` in the relevant file.
3. Use `DOMPurify` to sanitize the `description` variable before parsing it with `DOMParser`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
