### PR TITLE
Fix code scanning alert no. 29: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "jquery": "^3.7.1",
     "path-browserify": "^1.0.1",
     "preact": "^10.24.1",
-    "sonner": "^1.5.0"
+    "sonner": "^1.5.0",
+    "sanitize-html": "^2.13.1"
   },
   "packageManager": "yarn@4.5.0"
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -7,6 +7,7 @@ import {
   TORRENT_INFO, DOUBAN_MOBILE_API,
 } from './const';
 import i18nConfig from './i18n.json';
+import sanitizeHtml from 'sanitize-html';
 import { toast } from 'sonner';
 interface RequestOptions {
   method?: 'GET' | 'POST'
@@ -187,12 +188,12 @@ const getDoubanAwards = async (doubanId:string) => {
   });
   const doc = new DOMParser().parseFromString(data, 'text/html');
   const linkDom: HTMLLinkElement|null = doc.querySelector('#content > div > div.article');
-  return linkDom?.innerHTML
-    .replace(/[ \n]/g, '')
+  return sanitizeHtml(linkDom?.innerHTML ?? '', {
+    allowedTags: [],
+    allowedAttributes: {}
+  }).replace(/[ \n]/g, '')
     .replace(/<\/li><li>/g, '</li> <li>')
     .replace(/<\/a><span/g, '</a> <span')
-    .replace(/<(div|ul)[^>]*>/g, '\n')
-    .replace(/<[^>]+>/g, '')
     .replace(/&nbsp;/g, ' ')
     .replace(/ +\n/g, '\n')
     .trim();


### PR DESCRIPTION
Fixes [https://github.com/techmovie/easy-upload/security/code-scanning/29](https://github.com/techmovie/easy-upload/security/code-scanning/29)

To fix the problem, we should use a well-tested sanitization library to ensure that all potentially dangerous HTML tags and attributes are removed. The `sanitize-html` library is a good choice for this purpose. This library will handle all corner cases and ensure effective sanitization.

We will replace the current sanitization logic with a call to `sanitize-html`. This will involve importing the library and using it to sanitize the `innerHTML` content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
